### PR TITLE
Feature/knp navigation improvement

### DIFF
--- a/core-bundle/src/Event/FrontendMenuEvent.php
+++ b/core-bundle/src/Event/FrontendMenuEvent.php
@@ -21,15 +21,13 @@ class FrontendMenuEvent extends Event
     private FactoryInterface $factory;
     private ItemInterface $tree;
     private int $pid;
-    private int $level;
     private array $options;
 
-    public function __construct(FactoryInterface $factory, ItemInterface $tree, int $pid, int $level, array $options)
+    public function __construct(FactoryInterface $factory, ItemInterface $tree, int $pid, array $options)
     {
         $this->factory = $factory;
         $this->tree = $tree;
         $this->pid = $pid;
-        $this->level = $level;
         $this->options = $options;
     }
 
@@ -50,14 +48,6 @@ class FrontendMenuEvent extends Event
     public function getPid(): int
     {
         return $this->pid;
-    }
-
-    /**
-     * Get the current level of the navigation where "1" = top level.
-     */
-    public function getLevel(): int
-    {
-        return $this->level;
     }
 
     /**

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -284,17 +284,17 @@ abstract class Module extends Frontend
 		/** @var FrontendMenuBuilder $menuBuilder */
 		$menuBuilder = System::getContainer()->get('contao.menu.frontend_builder');
 		$root = System::getContainer()->get('knp_menu.factory')->createItem('root');
-	
+
 		$options = $this->arrData;
 		$options += array('isSitemap' => $this instanceof ModuleSitemap);
-	
+
 		$menu = $menuBuilder->getMenu($root, $pid, $level, $host, $options);
-	
+
 		if (!$menu->count())
 		{
 			return '';
 		}
-	
+
 		return $this->renderNavigationItems($menu, $level);
 	}
 
@@ -306,36 +306,37 @@ abstract class Module extends Frontend
 		$objTemplate->cssID = $this->cssID; // see #4897
 		$objTemplate->level = 'level_' . $level;
 		$objTemplate->module = $this; // see #155
-	
+
 		$objTemplate->items = $this->compileMenuItems($rootItem, $level);
-	
+
 		return !empty($objTemplate->items) ? $objTemplate->parse() : '';
 	}
 
 	protected function compileMenuItems(ItemInterface $rootItem, int $level): array
 	{
 		$items = array();
-	
+
 		foreach ($rootItem as $menuItem)
 		{
 			$subitems = '';
 
-			if ($menuItem->hasChildren() && $menuItem->getDisplayChildren()) {
+			if ($menuItem->hasChildren() && $menuItem->getDisplayChildren())
+			{
 				$subitems = $this->renderNavigationItems($menuItem, $level + 1);
 			}
-	
+
 			$items[] = $this->compileMenuItem($menuItem, $subitems);
 		}
-	
+
 		// Add first and last classes
 		if (!empty($items))
 		{
 			$last = \count($items) - 1;
-	
+
 			$items[0]['class'] = trim($items[0]['class'] . ' first');
 			$items[$last]['class'] = trim($items[$last]['class'] . ' last');
 		}
-	
+
 		return $items;
 	}
 

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -311,7 +311,7 @@ abstract class Module extends Frontend
 	protected function renderNavigationItems(ItemInterface $rootItem): string
 	{
 		$objTemplate = new FrontendTemplate($this->navigationTpl ?: 'nav_default');
-		$objTemplate->pid = $rootItem->getExtras()['pid'] ?? null;
+		$objTemplate->pid = $rootItem->getExtra('pid');
 		$objTemplate->type = static::class;
 		$objTemplate->cssID = $this->cssID; // see #4897
 		$objTemplate->level = 'level_' . ($rootItem->getLevel() + 1);

--- a/core-bundle/src/Resources/contao/modules/ModuleNavigation.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleNavigation.php
@@ -69,20 +69,10 @@ class ModuleNavigation extends Module
 			$level = ($this->levelOffset > 0) ? $this->levelOffset : 0;
 		}
 
-		$host = null;
-
-		// Overwrite the domain and language if the reference page belongs to a different root page (see #3765)
-		if ($this->defineRoot && $this->rootPage > 0)
-		{
-			$objRootPage = PageModel::findWithDetails($this->rootPage);
-
-			$host = $objRootPage->domain;
-		}
-
 		$this->Template->request = StringUtil::ampersand(Environment::get('indexFreeRequest'));
 		$this->Template->skipId = 'skipNavigation' . $this->id;
 		$this->Template->skipNavigation = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['skipNavigation']);
-		$this->Template->items = $this->renderNavigation($trail[$level], 1, $host);
+		$this->Template->items = $this->renderNavigation($trail[$level]);
 	}
 }
 

--- a/core-bundle/src/Resources/contao/modules/ModuleSitemap.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSitemap.php
@@ -55,29 +55,17 @@ class ModuleSitemap extends Module
 		/** @var PageModel $objPage */
 		global $objPage;
 
-		$lang = null;
-		$host = null;
-
 		// Start from the website root if there is no reference page
 		if (!$this->rootPage)
 		{
 			$this->rootPage = $objPage->rootId;
 		}
 
-		// Overwrite the domain and language if the reference page belongs to a different root page (see #3765)
-		else
-		{
-			$objRootPage = PageModel::findWithDetails($this->rootPage);
-
-			$lang = $objRootPage->rootLanguage;
-			$host = $objRootPage->domain;
-		}
-
 		$this->showLevel = 0;
 		$this->hardLimit = false;
 		$this->levelOffset = 0;
 
-		$this->Template->items = $this->renderNavigation($this->rootPage, 1, $host, $lang);
+		$this->Template->items = $this->renderNavigation($this->rootPage);
 	}
 }
 


### PR DESCRIPTION
This will render the Contao navigation recursively.

However, this does not fix the Contao navigation module completely. If you for example define a **Start level** of 1 and the current page has no subpages, then `FrontendMenuBuilder::populateMenuItem` will not be called for that menu node and thus the information is again missing in the `FrontendMenuEvent`.