### PR TITLE
Process each navigation item individually

### DIFF
--- a/core-bundle/src/Menu/FrontendMenuBuilder.php
+++ b/core-bundle/src/Menu/FrontendMenuBuilder.php
@@ -94,8 +94,8 @@ class FrontendMenuBuilder
         $pages = $this->getPages($pid, $options);
 
         /** @var PageModel $page */
-        foreach ($pages as ['page' => $page, 'hasSubpages' => $hasSubpages]) {
-            $child = $this->getMenu((int) $page->id, $options);
+        foreach ($pages as ['page' => $childPage, 'hasSubpages' => $hasSubpages]) {
+            $child = $this->getMenu((int) $childPage->id, array_merge($options, ['loadSubpages' => $hasSubpages]));
 
             if (null !== $child) {
                 $item->addChild($child);
@@ -193,6 +193,10 @@ class FrontendMenuBuilder
         // Custom page choice like, e.g., for the custom navigation module
         if (0 === $pid && $options['pages']) {
             return $this->findPagesByIds($options['pages']);
+        }
+
+        if (false === ($options['loadSubpages'] ?? null)) {
+            return [];
         }
 
         return $this->findPagesByPid($pid, (bool) $options['showHidden']);

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -294,14 +294,13 @@ abstract class Module extends Frontend
 
 		/** @var FrontendMenuBuilder $menuBuilder */
 		$menuBuilder = System::getContainer()->get('contao.menu.frontend_builder');
-		$root = System::getContainer()->get('knp_menu.factory')->createItem('root');
 
 		$options = $this->arrData;
 		$options += array('isSitemap' => $this instanceof ModuleSitemap);
 
-		$menu = $menuBuilder->getMenu($root, $pid, $options);
+		$menu = $menuBuilder->getMenu($pid, $options);
 
-		if (!$menu->count())
+		if (null === $menu || !$menu->count())
 		{
 			return '';
 		}

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -69,10 +69,10 @@ class ModuleCustomnav extends Module
 		$menuBuilder = System::getContainer()->get('contao.menu.frontend_builder');
 		$root = System::getContainer()->get('knp_menu.factory')->createItem('root');
 
-		$menu = $menuBuilder->getMenu($root, 0, $this->arrData);
+		$menu = $menuBuilder->getMenu(0, $this->arrData);
 
 		// Return if there are no pages
-		if (!$menu->count())
+		if (null === $menu || !$menu->count())
 		{
 			return;
 		}


### PR DESCRIPTION
This is a proposal for a different approach for the `getMenu` function. It treats each item individually, instead of processing only the children in the loop. It only requires one `populateMenuItem` call and only one event dispatching call. In the event all the information will be available. Although if you traverse up the tree, siblings of parents will be missing within the event (but that was also the case before, I think).

Quirks/notes/TODO:

* `hasSubmenu` is currently not in use.
* Note sure about database query efficiency …
* Tests are not updated yet.